### PR TITLE
Tt 4352 expose more resource api params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### QuickTravel Client Java
 
+## Unreleased
+
+* [TT-4352] Expose pricing api/resource parameters
+
 ## 0.4.0
 
 * [TT-4238] Add issued_tickets/barcodes endpoint

--- a/src/main/java/au/com/sealink/quicktravel/client/QuickTravelApiClient.java
+++ b/src/main/java/au/com/sealink/quicktravel/client/QuickTravelApiClient.java
@@ -35,7 +35,10 @@ public interface QuickTravelApiClient {
     @GET("resources")
     Single<List<Resource>> getResources(
             @Query("product_type_ids") List<Integer> productTypeIds,
-            @Query("web_site_id") Integer websiteId
+            @Query("web_site_id") Integer websiteId,
+            @Query("price") Boolean price,
+            @Query("children") Boolean children,
+            @Query("active_only") Boolean activeOnly
     );
 
     @GET("resource_categories")


### PR DESCRIPTION
### WHY

The companion application requires resources that are not bookable individually (resource is inside a package), to do this we have to explicitly request without_price.


