### PR TITLE
Tt 4351 timetable running states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### QuickTravel Client Java
 
+## Unreleased
+
+* [TT-4351] Add new scope parameter to timetable API
+
 ## 0.4.0
 
 * [TT-4238] Add issued_tickets/barcodes endpoint

--- a/src/main/java/au/com/sealink/quicktravel/client/QuickTravelApiClient.java
+++ b/src/main/java/au/com/sealink/quicktravel/client/QuickTravelApiClient.java
@@ -55,7 +55,8 @@ public interface QuickTravelApiClient {
     @GET("services/daily_timetable")
     Single<TimeTable> getDailyTimetable(
             @Query("product_type_id") int productTypeId,
-            @Query("date") String date
+            @Query("date") String date,
+            @Query("scope") String scope
     );
 
     @GET("product_types")


### PR DESCRIPTION
**WHY**

Companion application needs access to the stop sell states, so expose the parameter required in QuickTravel