### PR TITLE
TT 4433 global csrf handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [TT-4368] Add support for api/routes endpoint
 * [TT-4418] Add support for create/edit scheduled trip endpoints
+* [TT-4433] Add network interceptor for CRSF token
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,20 @@
 [![Build Status](https://travis-ci.org/sealink/quicktravel_client_java.svg?branch=master)](https://travis-ci.org/sealink/quicktravel_client_java)
 
 
-QuickTravel API library is a common use library developed primarly for use in the SeaLink Android
+QuickTravel API library is a common use library developed primarily for use in the SeaLink Android
 application suite, including Ticketing, Companion and Albert.
 
+#### Authentication
+
+Included with a valid login response is a CRSF token that is required to be passed as a header to
+all POST / PUT requests. To simplify this process you should use the provided TokenInterceptor class
+which implements the Retrofit Interceptor class.
+
+```
+    TokenInterceptor interceptor = new TokenInterceptor();
+    interceptor.setToken("");
+    new OkHttpClient.Builder().addInterceptor(interceptor).build();
+```
 
 #### Deployment
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation 'net.danlew:android.joda:2.9.5'
     testCompile 'joda-time:joda-time:2.9.5'
     testCompile 'junit:junit:4.12'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.10.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/src/main/java/au/com/sealink/quicktravel/client/QuickTravelApiClient.java
+++ b/src/main/java/au/com/sealink/quicktravel/client/QuickTravelApiClient.java
@@ -30,9 +30,7 @@ public interface QuickTravelApiClient {
     );
 
     @GET("api/logout")
-    Single<Response<ResponseBody>> logout(
-            @Header("X-CSRF-Token") String token
-    );
+    Single<Response<ResponseBody>> logout();
 
     @GET("api/issued_tickets/barcodes/{reference}")
     Single<EncryptedData> getBarcode(@Path("reference") String reference);
@@ -74,18 +72,11 @@ public interface QuickTravelApiClient {
     Single<List<Route>> getRoutes(@Path("productTypeId") int productTypeId);
 
     @POST("api/issued_tickets/board")
-    Single<List<BoardResult>> board(
-            @Header("X-CSRF-Token") String token,
-            @Body BoardRequest boardRequest
-    );
+    Single<List<BoardResult>> board(@Body BoardRequest boardRequest);
 
     @POST("reservation_for/scheduled_trips/find_services_for.json")
-    Single<List<Product>> findServicesFor(
-            @Header("X-CSRF-Token") String token,
-            @Body Search search);
+    Single<List<Product>> findServicesFor(@Body Search search);
 
     @POST("reservation_for/scheduled_trips")
-    Single<Booking> reservationFor(
-            @Header("X-CSRF-Token") String token,
-            @Body Create create);
+    Single<Booking> reservationFor(@Body Create create);
 }

--- a/src/main/java/au/com/sealink/quicktravel/client/retrofit/TokenInterceptor.java
+++ b/src/main/java/au/com/sealink/quicktravel/client/retrofit/TokenInterceptor.java
@@ -1,0 +1,28 @@
+package au.com.sealink.quicktravel.client.retrofit;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+
+public class TokenInterceptor implements Interceptor {
+    private volatile String token;
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public okhttp3.Response intercept(okhttp3.Interceptor.Chain chain) throws IOException {
+        Request request = chain.request();
+        if (!request.method().equals("GET")) {
+            String token = this.token;
+            if (token != null) {
+                request = request.newBuilder()
+                        .addHeader("X-CSRF-Token", token)
+                        .build();
+            }
+        }
+        return chain.proceed(request);
+    }
+}

--- a/src/test/java/au/com/sealink/quicktravel/client/retrofit/TokenInterceptorTest.java
+++ b/src/test/java/au/com/sealink/quicktravel/client/retrofit/TokenInterceptorTest.java
@@ -1,0 +1,73 @@
+package au.com.sealink.quicktravel.client.retrofit;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class TokenInterceptorTest {
+    @Test
+    public void testNullToken() throws Exception {
+        MockWebServer mockWebServer = new MockWebServer();
+        mockWebServer.enqueue(new MockResponse().setBody("hello, world"));
+        mockWebServer.start();
+
+        TokenInterceptor interceptor = new TokenInterceptor();
+        OkHttpClient okHttpClient = new OkHttpClient.Builder().addInterceptor(interceptor).build();
+
+        RequestBody body = RequestBody.create(MediaType.parse("application/json"), "{}");
+
+        Request request = new Request.Builder().url(mockWebServer.url("/")).post(body).build();
+        okHttpClient.newCall(request).execute();
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        Assert.assertEquals(null, recordedRequest.getHeader("X-CSRF-Token"));
+
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    public void testWithToken() throws Exception {
+        MockWebServer mockWebServer = new MockWebServer();
+        mockWebServer.enqueue(new MockResponse().setBody("hello, world"));
+        mockWebServer.start();
+
+        TokenInterceptor interceptor = new TokenInterceptor();
+        interceptor.setToken("ABC-123");
+        OkHttpClient okHttpClient = new OkHttpClient.Builder().addInterceptor(interceptor).build();
+
+        RequestBody body = RequestBody.create(MediaType.parse("application/json"), "{}");
+        Request request = new Request.Builder().url(mockWebServer.url("/")).post(body).build();
+        okHttpClient.newCall(request).execute();
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        Assert.assertEquals("ABC-123", recordedRequest.getHeader("X-CSRF-Token"));
+
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    public void testIgnoresGets() throws Exception {
+        MockWebServer mockWebServer = new MockWebServer();
+        mockWebServer.enqueue(new MockResponse().setBody("hello, world"));
+        mockWebServer.start();
+
+        TokenInterceptor interceptor = new TokenInterceptor();
+        interceptor.setToken("ABC-123");
+        OkHttpClient okHttpClient = new OkHttpClient.Builder().addInterceptor(interceptor).build();
+
+        Request request = new Request.Builder().url(mockWebServer.url("/")).build();
+        okHttpClient.newCall(request).execute();
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        Assert.assertEquals(null, recordedRequest.getHeader("X-CSRF-Token"));
+
+        mockWebServer.shutdown();
+    }
+}


### PR DESCRIPTION
#### Why

QuickTravels API is protected by CRSF so make it easier for API consumers to generate the required http request headers.