### PR TITLE
Use trusty distro so jdk8 builds work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 install: true
 jdk:
 - oraclejdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * [TT-5280] Add support for checkout status
+* [TT-5541] Fix build on travis
 
 ## 0.7.0
 


### PR DESCRIPTION
**WHY**

Fixes build issue on travis due to an upstream fix which correctly builds jdk8 code