### PR TITLE
Tt 6473 add timetable vessel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.1 Unreleased
 
 * [TT-6453] Add support for api/vessels endpoint
+* [TT-6473] Add departures `vessel_id` attribute
 
 ## 0.8.0
 

--- a/src/main/java/au/com/sealink/quicktravel/client/models/timetable/Departure.java
+++ b/src/main/java/au/com/sealink/quicktravel/client/models/timetable/Departure.java
@@ -22,6 +22,10 @@ public class Departure {
     @Expose
     int toRouteStopId;
 
+    @SerializedName("vessel_id")
+    @Expose
+    int vesselId;
+
     @SerializedName("state")
     @Expose
     String state;
@@ -41,6 +45,14 @@ public class Departure {
 
     public void setId(int id) {
         this.id = id;
+    }
+
+    public int getVesselIdId() {
+        return vesselId;
+    }
+
+    public void setVesselId(int vesselId) {
+        this.vesselId = vesselId;
     }
 
     public int getTripId() {

--- a/src/test/java/au/com/sealink/quicktravel/client/models/timetable/DepartureTest.java
+++ b/src/test/java/au/com/sealink/quicktravel/client/models/timetable/DepartureTest.java
@@ -14,6 +14,7 @@ public class DepartureTest {
         assertEquals("active", actual.getState());
         assertEquals(2, actual.getFromRouteStopId());
         assertEquals(3, actual.getToRouteStopId());
+        assertEquals(1, actual.getVesselIdId());
         assertEquals(DateHelper.parseIso("2018-06-14T09:00:00+09:30"), actual.getDepartsAt());
     }
 
@@ -32,6 +33,7 @@ public class DepartureTest {
         actual.setState("active");
         actual.setFromRouteStopId(2);
         actual.setToRouteStopId(3);
+        actual.setVesselId(1);
         actual.setDepartsAt(DateHelper.parseIso("2018-06-14T09:00:00+09:30"));
         assertData(actual);
     }

--- a/src/test/resources/fixtures/departure.json
+++ b/src/test/resources/fixtures/departure.json
@@ -1,6 +1,7 @@
 {
   "id": 7990793,
   "trip_id": 1,
+  "vessel_id": 1,
   "from_route_stop_id": 2,
   "to_route_stop_id": 3,
   "state": "active",


### PR DESCRIPTION
### WHY

SSA requires the vessel_id when scanning